### PR TITLE
Update cache before installing deps for bcrypt pip pkg

### DIFF
--- a/tasks/debian/prepare.yml
+++ b/tasks/debian/prepare.yml
@@ -1,5 +1,5 @@
 - name: Install dependencies for the bcrypt pip package
-  apt: name={{ item }} state=latest cache_valid_time=300
+  apt: name={{ item }} state=latest update_cache=yes
   with_items:
     - build-essential
     - libssl-dev


### PR DESCRIPTION
Not using update_cache=yes caused the playbook to fail on fresh instances.